### PR TITLE
Handle no transcript exception

### DIFF
--- a/linkedin_learning.py
+++ b/linkedin_learning.py
@@ -178,7 +178,11 @@ async def fetch_video(course: Course, chapter: Chapter, video: Video):
                 pass
 
         video_url = data['elements'][0]['selectedVideo']['url']['progressiveUrl']
-        subtitles = data['elements'][0]['selectedVideo']['transcript']['lines']
+        try:
+            subtitles = data['elements'][0]['selectedVideo']['transcript']['lines']
+        except:
+            logging.info(f"[*] No subtitles found for course '{course.name}' Chapter no. {chapter.index} Video no. {video.index}")
+            subtitles = []
         duration_in_ms = int(data['elements'][0]['selectedVideo']['durationInSeconds']) * 1000
 
         if not video_exists:


### PR DESCRIPTION
Some videos does not have transcript resulting in:
    subtitles = data['elements'][0]['selectedVideo']['transcript']['lines']
KeyError: 'transcript'

I added try/exception adding info logging and set subtitles to empty list